### PR TITLE
Use escape codes from `ansi-styles`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const isFullwidthCodePoint = require('is-fullwidth-code-point');
 const astralRegex = require('astral-regex');
+const ansiStyles = require('ansi-styles');
 
 const ESCAPES = [
 	'\u001B',
@@ -8,34 +9,6 @@ const ESCAPES = [
 ];
 
 const END_CODE = 39;
-
-const ESCAPE_CODES = new Map([
-	[0, 0],
-	[1, 22],
-	[2, 22],
-	[3, 23],
-	[4, 24],
-	[7, 27],
-	[8, 28],
-	[9, 29],
-	[30, 39],
-	[31, 39],
-	[32, 39],
-	[33, 39],
-	[34, 39],
-	[35, 39],
-	[36, 39],
-	[37, 39],
-	[90, 39],
-	[40, 49],
-	[41, 49],
-	[42, 49],
-	[43, 49],
-	[44, 49],
-	[45, 49],
-	[46, 49],
-	[47, 49]
-]);
 
 const wrapAnsi = code => `${ESCAPES[0]}[${code}m`;
 
@@ -78,7 +51,7 @@ module.exports = (str, begin, end) => {
 			output += wrapAnsi(escapeCode);
 		} else if (visible >= end) {
 			if (escapeCode !== undefined) {
-				output += wrapAnsi(ESCAPE_CODES.get(parseInt(escapeCode, 10)) || END_CODE);
+				output += wrapAnsi(ansiStyles.codes.get(parseInt(escapeCode, 10)) || END_CODE);
 			}
 			break;
 		}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "text"
   ],
   "dependencies": {
+    "ansi-styles": "^3.2.0",
     "astral-regex": "^1.0.0",
     "is-fullwidth-code-point": "^2.0.0"
   },


### PR DESCRIPTION
Fixes #12.