### PR TITLE
Add failing tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -49,3 +49,11 @@ test('supports unicode surrogate pairs', t => {
 test('doesn\'t add unnecessary escape codes', t => {
 	t.is(m('\u001B[31municorn\u001B[39m', 0, 3), '\u001B[31muni\u001B[39m');
 });
+
+test.failing('can slice a normal character before a colored character', t => {
+	t.is(m('a\u001B[31mb\u001B[39m', 0, 1), 'a');
+});
+
+test.failing('can slice a normal character after a colored character', t => {
+	t.is(m('\u001B[31ma\u001B[39mb', 1, 2), 'b');
+});


### PR DESCRIPTION
I rewrote to add minimum tests to reproduce the contents of #14 .

----

<details>
  <summary>Contents of an old description</summary>
Hello.

Fix to work correctly when ordinary string and ANSI string are mixed.

In order to fix bugs, I fixed the places that I seemed wrong with internal logic. 
Although the correction range has become wide, can you confirm it?

Especially I did not know the situation that needed `ansi-styles`.

Ref) #14 


### Problem summary

reproduce.js)
```js
const sliceAnsi = require('./index');
const chalk = require('chalk');

const str = 'a' + chalk.red('bc') + 'd';

console.log('a:', sliceAnsi(str, 0, 1) === 'a');
console.log('b:', sliceAnsi(str, 1, 2) === chalk.red('b'));
console.log('c:', sliceAnsi(str, 2, 3) === chalk.red('c'));
console.log('d:', sliceAnsi(str, 3, 4) === 'd');
```

before)
```bash
node reproduce.js 
a: false
b: true
c: false
d: false
```

after)
```bash
node reproduce.js 
a: true
b: true
c: true
d: true
```
</details>