### PR TITLE
Accept true color escape sequences

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (str, begin, end) => {
 
 		if (ESCAPES.indexOf(x) !== -1) {
 			insideEscape = true;
-			const code = /\d[^m]*/.exec(str.slice(i, i + 4));
+			const code = /\d[^m]*/.exec(str.slice(i, i + 18));
 			escapeCode = code === END_CODE ? null : code;
 		} else if (insideEscape && x === 'm') {
 			insideEscape = false;

--- a/test.js
+++ b/test.js
@@ -51,5 +51,5 @@ test('doesn\'t add unnecessary escape codes', t => {
 });
 
 test('support true color escape sequences', t => {
-	t.is(m('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m');
+	t.is(sliceAnsi('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m');
 });


### PR DESCRIPTION
The slice only pick 4 bytes, not enough for longer escape sequences. This change increase it to 18, allowing to accept escape sequences for true color definitions. I have not used an unbounded limit to don't check the regular expression against probably very long strings.

Fix #17