### PR TITLE
Add a failing test for extra ansi escapes

### DIFF
--- a/test.js
+++ b/test.js
@@ -69,7 +69,7 @@ test('support true color escape sequences', t => {
 });
 
 test.failing('doesn\'t add extra escapes', t => {
-	const s = '\u001b[30m\u001b[43m RUNS \u001b[49m\u001b[39m  \u001b[32mtest\u001b[39m';
-	t.is(sliceAnsi(s, 0, 7), '\u001b[30m\u001b[43m RUNS \u001b[49m\u001b[39m ');
-	t.is(sliceAnsi(s, 0, 8), '\u001b[30m\u001b[43m RUNS \u001b[49m\u001b[39m  ');
+	const s = '\u001B[30m\u001B[43m RUNS \u001B[49m\u001B[39m  \u001B[32mtest\u001B[39m';
+	t.is(sliceAnsi(s, 0, 7), '\u001B[30m\u001B[43m RUNS \u001B[49m\u001B[39m ');
+	t.is(sliceAnsi(s, 0, 8), '\u001B[30m\u001B[43m RUNS \u001B[49m\u001B[39m  ');
 });

--- a/test.js
+++ b/test.js
@@ -68,6 +68,7 @@ test('support true color escape sequences', t => {
 	t.is(sliceAnsi('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m');
 });
 
+// See https://github.com/chalk/slice-ansi/issues/24
 test.failing('doesn\'t add extra escapes', t => {
 	const output = `${chalk.black.bgYellow(' RUNS ')}  ${chalk.green('test')}`;
 	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} `);

--- a/test.js
+++ b/test.js
@@ -69,7 +69,7 @@ test('support true color escape sequences', t => {
 });
 
 test.failing('doesn\'t add extra escapes', t => {
-	const s = '\u001B[30m\u001B[43m RUNS \u001B[49m\u001B[39m  \u001B[32mtest\u001B[39m';
-	t.is(sliceAnsi(s, 0, 7), '\u001B[30m\u001B[43m RUNS \u001B[49m\u001B[39m ');
-	t.is(sliceAnsi(s, 0, 8), '\u001B[30m\u001B[43m RUNS \u001B[49m\u001B[39m  ');
+	const output = `${chalk.black.bgYellow(' RUNS ')}  ${chalk.green('test')}`;
+	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} `);
+	t.is(sliceAnsi(output, 0, 8), `${chalk.black.bgYellow(' RUNS ')}  `);
 });

--- a/test.js
+++ b/test.js
@@ -67,3 +67,9 @@ test('weird null issue', t => {
 test('support true color escape sequences', t => {
 	t.is(sliceAnsi('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m');
 });
+
+test.failing('doesn\'t add extra escapes', t => {
+	const s = '\u001b[30m\u001b[43m RUNS \u001b[49m\u001b[39m  \u001b[32mtest\u001b[39m';
+	t.is(sliceAnsi(s, 0, 7), '\u001b[30m\u001b[43m RUNS \u001b[49m\u001b[39m ');
+	t.is(sliceAnsi(s, 0, 8), '\u001b[30m\u001b[43m RUNS \u001b[49m\u001b[39m  ');
+});


### PR DESCRIPTION
For some reason when there's a space or multiple spaces at the end, `slice-ansi` adds closing escape (`\u001b[39m`) at the end of the string.