### PR TITLE
Get all ansi escape sequences

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = (string, begin, end) => {
 		} else if (visible === begin && !isInsideEscape && ansiCode !== undefined) {
 			output += wrapAnsi(ansiCode);
 		} else if (visible >= end) {
-			for (let aansiCode of ansiCodes) {
+			for (let ansiCode of ansiCodes) {
 				if (aansiCode.match(';')) {
 					aansiCode = aansiCode.split(';')[0][0] + '0';
 				}

--- a/index.js
+++ b/index.js
@@ -31,12 +31,17 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 		} else if (isEscapes) {
 			output.push(wrapAnsi(0));
 			break;
+		} else {
+			output.push(wrapAnsi(ansiCodeOrigin));
 		}
 	}
 
-	if (endAnsiCode !== undefined) {
-		const fistEscapeCode = wrapAnsi(ansiStyles.codes.get(parseInt(endAnsiCode, 10)));
-		output = output.reduce((current, next) => next === fistEscapeCode ? [next, ...current] : [...current, next], []);
+	if (isEscapes) {
+		output = output.filter((element, index) => output.indexOf(element) === index);
+		if (endAnsiCode !== undefined) {
+			const fistEscapeCode = wrapAnsi(ansiStyles.codes.get(parseInt(endAnsiCode, 10)));
+			output = output.reduce((current, next) => next === fistEscapeCode ? [next, ...current] : [...current, next], []);
+		}
 	}
 
 	return output.join('');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"text"
 	],
 	"dependencies": {
+		"ansi-styles": "^3.2.0",
 		"astral-regex": "^1.0.0",
 		"is-fullwidth-code-point": "^2.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"text"
 	],
 	"dependencies": {
-		"ansi-styles": "^3.2.0",
 		"astral-regex": "^1.0.0",
 		"is-fullwidth-code-point": "^2.0.0"
 	},

--- a/test.js
+++ b/test.js
@@ -61,7 +61,7 @@ test('can slice a normal character after a colored character', t => {
 // See https://github.com/chalk/slice-ansi/issues/22
 test('can slice a string styled with both background and foreground', t => {
 	// Test string: `chalk.bgGreen.black('test');`
-	t.is(sliceAnsi('\u001B[42m\u001B[30mtest\u001B[39m\u001B[49m', 0, 1), '\u001B[42m\u001B[30mt\u001B[49m\u001B[39m');
+	t.is(sliceAnsi('\u001B[42m\u001B[30mtest\u001B[39m\u001B[49m', 0, 1), '\u001B[42m\u001B[30mt\u001B[39m\u001B[49m');
 });
 
 test('weird null issue', t => {

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ test('main', t => {
 	}
 
 	const a = util.inspect('\u001B[31mthe \u001B[39m\u001B[32mquick \u001B[39m');
-	const b = util.inspect('\u001B[32m\u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m');
+	const b = util.inspect('\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m');
 	const c = util.inspect('\u001B[31m \u001B[39m\u001B[32mquick \u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m');
 
 	t.is(util.inspect(sliceAnsi(fixture, 0, 10)), a);
@@ -55,7 +55,7 @@ test('can slice a normal character before a colored character', t => {
 });
 
 test('can slice a normal character after a colored character', t => {
-	t.is(sliceAnsi('\u001B[31ma\u001B[39mb', 1, 2), '\u001B[31m\u001B[39mb');
+	t.is(sliceAnsi('\u001B[31ma\u001B[39mb', 1, 2), 'b');
 });
 
 // See https://github.com/chalk/slice-ansi/issues/22

--- a/test.js
+++ b/test.js
@@ -64,6 +64,17 @@ test('can slice a string styled with both background and foreground', t => {
 	t.is(sliceAnsi('\u001B[42m\u001B[30mtest\u001B[39m\u001B[49m', 0, 1), '\u001B[42m\u001B[30mt\u001B[39m\u001B[49m');
 });
 
+test('can slice a string styled with modifier', t => {
+	// Test string: `chalk.underline('test');`
+	t.is(sliceAnsi('\u001B[4mtest\u001B[24m', 0, 1), '\u001B[4mt\u001B[24m');
+});
+
+test('can slice a string with unknown ANSI color', t => {
+	t.is(sliceAnsi('\u001B[20mTEST\u001B[49m', 0, 4), '\u001B[20mTEST\u001B[0m');
+	t.is(sliceAnsi('\u001B[1001mTEST\u001B[49m', 0, 3), '\u001B[1001mTES\u001B[0m');
+	t.is(sliceAnsi('\u001B[1001mTEST\u001B[49m', 0, 2), '\u001B[1001mTE\u001B[0m');
+});
+
 test('weird null issue', t => {
 	const s = '\u001B[1mautotune.flipCoin("easy as") ? 🎂 : 🍰 \u001B[33m★\u001B[39m\u001B[22m';
 	const result = sliceAnsi(s, 38);
@@ -79,4 +90,5 @@ test('doesn\'t add extra escapes', t => {
 	const output = `${chalk.black.bgYellow(' RUNS ')}  ${chalk.green('test')}`;
 	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} `);
 	t.is(sliceAnsi(output, 0, 8), `${chalk.black.bgYellow(' RUNS ')}  `);
+	t.is(sliceAnsi('\u001B[31m' + output, 0, 4), `\u001B[31m${chalk.black.bgYellow(' RUN')}`);
 });

--- a/test.js
+++ b/test.js
@@ -24,9 +24,9 @@ test('main', t => {
 		}
 	}
 
-	const a = util.inspect('\u001B[31mthe \u001B[39m\u001B[32mquick \u001B[39m\u001B[34m\u001B[39m\u001B[36m\u001B[39m\u001B[33m\u001B[39m');
-	const b = util.inspect('\u001B[32m\u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m\u001B[33m\u001B[39m');
-	const c = util.inspect('\u001B[31m \u001B[39m\u001B[32mquick \u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m\u001B[33m\u001B[39m');
+	const a = util.inspect('\u001B[31mthe \u001B[39m\u001B[32mquick \u001B[39m');
+	const b = util.inspect('\u001B[32m\u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m');
+	const c = util.inspect('\u001B[31m \u001B[39m\u001B[32mquick \u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m');
 
 	t.is(util.inspect(sliceAnsi(fixture, 0, 10)), a);
 	t.is(util.inspect(sliceAnsi(fixture, 10, 20)), b);
@@ -51,15 +51,17 @@ test('doesn\'t add unnecessary escape codes', t => {
 });
 
 test('can slice a normal character before a colored character', t => {
-	t.is(sliceAnsi('a\u001B[31mb\u001B[39m', 0, 1), 'a\u001B[31m\u001B[39m');
+	t.is(sliceAnsi('a\u001B[31mb\u001B[39m', 0, 1), 'a');
 });
 
 test('can slice a normal character after a colored character', t => {
 	t.is(sliceAnsi('\u001B[31ma\u001B[39mb', 1, 2), '\u001B[31m\u001B[39mb');
 });
 
+// See https://github.com/chalk/slice-ansi/issues/22
 test('can slice a string styled with both background and foreground', t => {
-	t.is(sliceAnsi('\u001B[42m\u001B[30mtest\u001B[39m\u001B[49m', 0, 1), '\u001B[42m\u001B[30mt\u001B[39m\u001B[49m');
+	// Test string: `chalk.bgGreen.black('test');`
+	t.is(sliceAnsi('\u001B[42m\u001B[30mtest\u001B[39m\u001B[49m', 0, 1), '\u001B[42m\u001B[30mt\u001B[49m\u001B[39m');
 });
 
 test('weird null issue', t => {
@@ -69,11 +71,12 @@ test('weird null issue', t => {
 });
 
 test('support true color escape sequences', t => {
-	t.is(sliceAnsi('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m\u001B[49m\u001B[22m');
+	t.is(sliceAnsi('\u001B[1m\u001B[48;2;255;255;255m\u001B[38;2;255;0;0municorn\u001B[39m\u001B[49m\u001B[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;255m\u001B[38;2;255;0;0muni\u001B[22m\u001B[49m\u001B[39m');
 });
 
+// See https://github.com/chalk/slice-ansi/issues/24
 test('doesn\'t add extra escapes', t => {
 	const output = `${chalk.black.bgYellow(' RUNS ')}  ${chalk.green('test')}`;
-	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} \u001B[32m\u001B[39m`);
-	t.is(sliceAnsi(output, 0, 8), `${chalk.black.bgYellow(' RUNS ')}  \u001B[32m\u001B[39m`);
+	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} `);
+	t.is(sliceAnsi(output, 0, 8), `${chalk.black.bgYellow(' RUNS ')}  `);
 });

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ test('main', t => {
 		}
 	}
 
-	const a = util.inspect('\u001B[31mthe \u001B[39m\u001B[32mquick \u001B[39m\u001B[34m\u001B[39m');
+	const a = util.inspect('\u001B[31mthe \u001B[39m\u001B[32mquick \u001B[39m\u001B[34m\u001B[39m\u001B[36m\u001B[39m\u001B[33m\u001B[39m');
 	const b = util.inspect('\u001B[32m\u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m\u001B[33m\u001B[39m');
 	const c = util.inspect('\u001B[31m \u001B[39m\u001B[32mquick \u001B[39m\u001B[34mbrown \u001B[39m\u001B[36mfox \u001B[39m\u001B[33m\u001B[39m');
 
@@ -50,17 +50,15 @@ test('doesn\'t add unnecessary escape codes', t => {
 	t.is(sliceAnsi('\u001B[31municorn\u001B[39m', 0, 3), '\u001B[31muni\u001B[39m');
 });
 
-test.failing('can slice a normal character before a colored character', t => {
-	t.is(sliceAnsi('a\u001B[31mb\u001B[39m', 0, 1), 'a');
+test('can slice a normal character before a colored character', t => {
+	t.is(sliceAnsi('a\u001B[31mb\u001B[39m', 0, 1), 'a\u001B[31m\u001B[39m');
 });
 
-test.failing('can slice a normal character after a colored character', t => {
-	t.is(sliceAnsi('\u001B[31ma\u001B[39mb', 1, 2), 'b');
+test('can slice a normal character after a colored character', t => {
+	t.is(sliceAnsi('\u001B[31ma\u001B[39mb', 1, 2), '\u001B[31m\u001B[39mb');
 });
 
-// See https://github.com/chalk/slice-ansi/issues/22
-test.failing('can slice a string styled with both background and foreground', t => {
-	// Test string: `chalk.bgGreen.black('test');`
+test('can slice a string styled with both background and foreground', t => {
 	t.is(sliceAnsi('\u001B[42m\u001B[30mtest\u001B[39m\u001B[49m', 0, 1), '\u001B[42m\u001B[30mt\u001B[39m\u001B[49m');
 });
 
@@ -71,12 +69,11 @@ test('weird null issue', t => {
 });
 
 test('support true color escape sequences', t => {
-	t.is(sliceAnsi('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m');
+	t.is(sliceAnsi('\u001B[[1m\u001B[[48;2;255;255;255m\u001B[[38;2;255;0;0municorn\u001B[[39m\u001B[[49m\u001B[[22m', 0, 3), '\u001B[1m\u001B[48;2;255;255;25m\u001B[38;2;255;0;0muni\u001B[39m\u001B[49m\u001B[22m');
 });
 
-// See https://github.com/chalk/slice-ansi/issues/24
-test.failing('doesn\'t add extra escapes', t => {
+test('doesn\'t add extra escapes', t => {
 	const output = `${chalk.black.bgYellow(' RUNS ')}  ${chalk.green('test')}`;
-	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} `);
-	t.is(sliceAnsi(output, 0, 8), `${chalk.black.bgYellow(' RUNS ')}  `);
+	t.is(sliceAnsi(output, 0, 7), `${chalk.black.bgYellow(' RUNS ')} \u001B[32m\u001B[39m`);
+	t.is(sliceAnsi(output, 0, 8), `${chalk.black.bgYellow(' RUNS ')}  \u001B[32m\u001B[39m`);
 });


### PR DESCRIPTION
# Summary: 
- Replace default end code `39m` ~> `0m` (Work with "true color", background & foreground)
- Sort end codes
- Work with background
- Work with "true color"
- Fix "true color" test
- Remove ansi code at the end not used

# Fix
Closes #14
Closes #22
Closes #24