### PR TITLE
Adjust string length for fullwidth characters when `end` is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,7 @@ module.exports = (string, begin, end) => {
 	const characters = [...string.normalize()];
 	const ansiCodes = [];
 
-	end = typeof end === 'number' ? end : characters.length;
-
+	let stringEnd = typeof end === 'number' ? end : characters.length;
 	let isInsideEscape = false;
 	let ansiCode;
 	let visible = 0;
@@ -64,7 +63,7 @@ module.exports = (string, begin, end) => {
 		if (ESCAPES.includes(character)) {
 			const code = /\d[^m]*/.exec(string.slice(index, index + 18));
 			ansiCode = code && code.length > 0 ? code[0] : undefined;
-			if (visible < end) {
+			if (visible < stringEnd) {
 				isInsideEscape = true;
 				if (ansiCode !== undefined) {
 					ansiCodes.push(ansiCode);
@@ -81,13 +80,17 @@ module.exports = (string, begin, end) => {
 
 		if (!astralRegex({exact: true}).test(character) && isFullwidthCodePoint(character.codePointAt())) {
 			++visible;
+
+			if (typeof end !== 'number') {
+				++stringEnd;
+			}
 		}
 
-		if (visible > begin && visible <= end) {
+		if (visible > begin && visible <= stringEnd) {
 			output += character;
 		} else if (visible === begin && !isInsideEscape && ansiCode !== undefined) {
 			output = checkAnsi(ansiCodes);
-		} else if (visible >= end) {
+		} else if (visible >= stringEnd) {
 			output += checkAnsi(ansiCodes, true, ansiCode);
 			break;
 		}

--- a/test.js
+++ b/test.js
@@ -94,6 +94,6 @@ test('doesn\'t add extra escapes', t => {
 });
 
 // See https://github.com/chalk/slice-ansi/issues/26
-test.failing('does not lose fullwidth characters', t => {
+test('does not lose fullwidth characters', t => {
 	t.is(sliceAnsi('古古test', 0), '古古test');
 });


### PR DESCRIPTION
Fixes #26.
Closes #29.