### PR TITLE
Don't normalize the input string

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 };
 
 module.exports = (string, begin, end) => {
-	const characters = [...string.normalize()];
+	const characters = [...string];
 	const ansiCodes = [];
 
 	end = typeof end === 'number' ? end : characters.length;

--- a/test.js
+++ b/test.js
@@ -97,8 +97,3 @@ test('doesn\'t add extra escapes', t => {
 test.failing('does not lose fullwidth characters', t => {
 	t.is(sliceAnsi('古古test', 0), '古古test');
 });
-
-// See https://github.com/chalk/slice-ansi/pull/27#issuecomment-533216774
-test('does not perform string normalization', t => {
-	t.is(sliceAnsi('\u006E\u0303test', 0), '\u006E\u0303test');
-});

--- a/test.js
+++ b/test.js
@@ -97,3 +97,8 @@ test('doesn\'t add extra escapes', t => {
 test.failing('does not lose fullwidth characters', t => {
 	t.is(sliceAnsi('古古test', 0), '古古test');
 });
+
+// See https://github.com/chalk/slice-ansi/pull/27#issuecomment-533216774
+test('does not perform string normalization', t => {
+	t.is(sliceAnsi('\u006E\u0303test', 0), '\u006E\u0303test');
+});


### PR DESCRIPTION
While nifty, and visually it doesn't have an impact. However, when comparing a normalized string to a normal they can differ even though they look the same on the surface. Also, it's not needed for this module to function correctly.

See https://github.com/chalk/slice-ansi/pull/27#issuecomment-533216774 for more details.