### PR TITLE
supports fullwidth characters & not specified end

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = (string, begin, end) => {
 	if (typeof end !== 'number') {
 		end = characters.length;
 		for (const character of characters.entries()) {
-			if (isFullwidthCodePoint(character.codePointAt())) {
+			if (isFullwidthCodePoint(character[1].codePointAt())) {
 				++end;
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = (string, begin, end) => {
 	let ansiCode;
 	let visible = 0;
 	let output = '';
-	let beginned = false;
+	let isTextStarted = false;
 
 	for (const [index, character] of characters.entries()) {
 		let leftEscape = false;
@@ -92,8 +92,8 @@ module.exports = (string, begin, end) => {
 		}
 
 		if (visible > begin && visible <= end) {
-			if (!beginned) {
-				beginned = true;
+			if (!isTextStarted) {
+				isTextStarted = true;
 				if (!isInsideEscape && ansiCode !== undefined) {
 					output = checkAnsi(ansiCodes);
 				}

--- a/index.js
+++ b/index.js
@@ -51,12 +51,18 @@ module.exports = (string, begin, end) => {
 	const characters = [...string];
 	const ansiCodes = [];
 
-	end = typeof end === 'number' ? end : characters.length;
+	if(typeof end !== 'number') {
+		end = characters.length;
+		for (const [index, character] of characters.entries()) {
+			if(isFullwidthCodePoint(character.codePointAt())) ++end;
+		}
+	}
 
 	let isInsideEscape = false;
 	let ansiCode;
 	let visible = 0;
 	let output = '';
+	let beginned = false;
 
 	for (const [index, character] of characters.entries()) {
 		let leftEscape = false;
@@ -84,9 +90,12 @@ module.exports = (string, begin, end) => {
 		}
 
 		if (visible > begin && visible <= end) {
-			output += character;
-		} else if (visible === begin && !isInsideEscape && ansiCode !== undefined) {
-			output = checkAnsi(ansiCodes);
+			if(!beginned) {
+				beginned = true;
+				if(!isInsideEscape && ansiCode !== undefined)
+					output = checkAnsi(ansiCodes);
+      		}
+			output += character; 
 		} else if (visible >= end) {
 			output += checkAnsi(ansiCodes, true, ansiCode);
 			break;

--- a/index.js
+++ b/index.js
@@ -51,10 +51,12 @@ module.exports = (string, begin, end) => {
 	const characters = [...string];
 	const ansiCodes = [];
 
-	if(typeof end !== 'number') {
+	if (typeof end !== 'number') {
 		end = characters.length;
-		for (const [index, character] of characters.entries()) {
-			if(isFullwidthCodePoint(character.codePointAt())) ++end;
+		for (const character of characters.entries()) {
+			if (isFullwidthCodePoint(character.codePointAt())) {
+				++end;
+			}
 		}
 	}
 
@@ -90,12 +92,14 @@ module.exports = (string, begin, end) => {
 		}
 
 		if (visible > begin && visible <= end) {
-			if(!beginned) {
+			if (!beginned) {
 				beginned = true;
-				if(!isInsideEscape && ansiCode !== undefined)
+				if (!isInsideEscape && ansiCode !== undefined) {
 					output = checkAnsi(ansiCodes);
-      		}
-			output += character; 
+				}
+			}
+
+			output += character;
 		} else if (visible >= end) {
 			output += checkAnsi(ansiCodes, true, ansiCode);
 			break;

--- a/package.json
+++ b/package.json
@@ -37,9 +37,8 @@
 		"text"
 	],
 	"dependencies": {
-		"ansi-styles": "^4.2.0",
+		"ansi-styles": "^4.0.0",
 		"astral-regex": "^2.0.0",
-		"fullwidth": "^1.2.0",
 		"is-fullwidth-code-point": "^3.0.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
 		"text"
 	],
 	"dependencies": {
-		"ansi-styles": "^4.0.0",
+		"ansi-styles": "^4.2.0",
 		"astral-regex": "^2.0.0",
+		"fullwidth": "^1.2.0",
 		"is-fullwidth-code-point": "^3.0.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -94,6 +94,12 @@ test('doesn\'t add extra escapes', t => {
 });
 
 // See https://github.com/chalk/slice-ansi/issues/26
-test.failing('does not lose fullwidth characters', t => {
+test('does not lose fullwidth characters', t => {
 	t.is(sliceAnsi('古古test', 0), '古古test');
 });
+
+test('fullwidth characters + ANSI codes', t => {
+	t.is(sliceAnsi('\u001B[31m古古test\u001B[39m', 3), '\u001B[31m古test\u001B[39m');
+	t.is(sliceAnsi('\u001B[31m古古test\u001B[39m', 3, 4), '\u001B[31m古\u001B[39m');
+});
+


### PR DESCRIPTION
Might need some cost-efficiency evaluation to be done. Also, I suggest one of the following libraries to be considered for future revisions:
- https://github.com/orling/grapheme-splitter
- https://github.com/bestiejs/punycode.js

This, of course, seeing how they are taking into account ISO standards relating to special characters readability and usability. Hope it works now.

P.S.: I looked at the previously cancelled pull, and made sure the tests complied. Hope it works.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#26: Lose characters when fullwidth characters exist and end is not specified](https://issuehunt.io/repos/43191689/issues/26)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->