### PR TITLE
improve performance (+99.5% throughput)

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,30 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 	return output.join('');
 };
 
+function findNumberIndex(string) {
+	for (let index = 0; index < string.length; index++) {
+		const charCode = string.charCodeAt(index);
+		if (charCode >= 48 && charCode <= 57) {
+			return index;
+		}
+	}
+
+	return -1;
+}
+
+function parseAnsiCode(string, offset) {
+	string = string.slice(offset, offset + 18);
+	const startIndex = findNumberIndex(string);
+	if (startIndex !== -1) {
+		let endIndex = string.indexOf('m', startIndex);
+		if (endIndex === -1) {
+			endIndex = string.length;
+		}
+
+		return string.slice(startIndex, endIndex);
+	}
+}
+
 export default function sliceAnsi(string, begin, end) {
 	const ansiCodes = [];
 	const characters = [...string];
@@ -66,8 +90,7 @@ export default function sliceAnsi(string, begin, end) {
 		let leftEscape = false;
 
 		if (ESCAPES.includes(character)) {
-			const code = /\d[^m]*/.exec(string.slice(index, index + 18));
-			ansiCode = code && code.length > 0 ? code[0] : undefined;
+			ansiCode = parseAnsiCode(string, index);
 
 			if (visible < stringEnd) {
 				isInsideEscape = true;

--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 
 	for (let ansiCode of ansiCodes) {
 		const ansiCodeOrigin = ansiCode;
-		if (ansiCode.includes(';')) {
-			ansiCode = ansiCode.split(';')[0][0] + '0';
+		const semiIndex = ansiCode.indexOf(';');
+		if (semiIndex > -1) {
+			ansiCode = ansiCode.slice(0, Math.min(1, semiIndex)) + '0';
 		}
 
 		const item = escapeCodes.get(ansiCode);

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 };
 
 export default function sliceAnsi(string, begin, end) {
-	const characters = [...string];
 	const ansiCodes = [];
+	const characters = [...string];
 
 	let stringEnd = typeof end === 'number' ? end : characters.length;
 	let isInsideEscape = false;
@@ -60,7 +60,9 @@ export default function sliceAnsi(string, begin, end) {
 	let visible = 0;
 	let output = '';
 
-	for (const [index, character] of characters.entries()) {
+	// eslint-disable-next-line unicorn/no-for-loop
+	for (let index = 0; index < characters.length; index++) {
+		const character = characters[index];
 		let leftEscape = false;
 
 		if (ESCAPES.includes(character)) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ const ESCAPES = [
 	'\u009B'
 ];
 
+const escapeCodes = new Map();
+for (const [start, end] of ansiStyles.codes) {
+	escapeCodes.set(start.toString(), end.toString());
+}
+
 const wrapAnsi = code => `${ESCAPES[0]}[${code}m`;
 
 const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
@@ -18,9 +23,9 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 			ansiCode = ansiCode.split(';')[0][0] + '0';
 		}
 
-		const item = ansiStyles.codes.get(Number.parseInt(ansiCode, 10));
+		const item = escapeCodes.get(ansiCode);
 		if (item) {
-			const indexEscape = ansiCodes.indexOf(item.toString());
+			const indexEscape = ansiCodes.indexOf(item);
 			if (indexEscape === -1) {
 				output.push(wrapAnsi(isEscapes ? item : ansiCodeOrigin));
 			} else {
@@ -38,7 +43,7 @@ const checkAnsi = (ansiCodes, isEscapes, endAnsiCode) => {
 		output = output.filter((element, index) => output.indexOf(element) === index);
 
 		if (endAnsiCode !== undefined) {
-			const fistEscapeCode = wrapAnsi(ansiStyles.codes.get(Number.parseInt(endAnsiCode, 10)));
+			const fistEscapeCode = wrapAnsi(escapeCodes.get(endAnsiCode));
 			// TODO: Remove the use of `.reduce` here.
 			// eslint-disable-next-line unicorn/no-array-reduce
 			output = output.reduce((current, next) => next === fistEscapeCode ? [next, ...current] : [...current, next], []);


### PR DESCRIPTION
As mentioned in https://github.com/vadimdemedes/ink/issues/560, I'm having severe performance issues with this library. This PR is an attempt at making it faster. 

I suggest reviewing the changes commit-by-commit, while reading the corresponding change description and benchmark. The last commit is a complete rewrite though.

I'm testing the impact of each change using the following benchmark:
```js
import b from "benny";
import sliceAnsi from "./original.js";
// import optimized variants

// This might seem ridiculous, but it's from the test case I posted over at the `ink` issue.
const line = "\x1B[48;2;255;255;255m│\x1B[49m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m\x1B[37m╚═╝\x1B[39m                                                                                                                                                                             \x1B[34m│\x1B[39m";

const add = (name, fn) =>
	b.add(name, fn, {
		initCount: 10000,
	});

b.suite(
	"sliceAnsi",
	add("original", () => {
		sliceAnsi(line, 0, 82);
		sliceAnsi(line, 82, 83);
		sliceAnsi(line, 83);
	}),
	// test optimized variants

	b.cycle(),
	b.complete()
);
```

The results are varying between tests a bit, but I'll try to post comparable benchmarks for each change.

### First change: Use a simple for loop instead of calling `entries()` on the character array
Result:
```
  original:
    21 976 ops/s, ±6.14%   | slowest, 10.01% slower

  for loop:
    24 420 ops/s, ±2.74%   | fastest
```